### PR TITLE
Fix instagram link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -340,7 +340,7 @@ export default function MacarenaGelateria() {
           >
             <a
               id="instagram-link"
-              href="https://instagram.com"
+              href="https://www.instagram.com/macarenagelateria?igsh=MTRmbDhlYmY3aG54dw=="
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block px-6 py-3 text-base font-medium rounded-full border-2 bg-transparent cursor-pointer hover:bg-opacity-20 hover:shadow-2xl hover:shadow-slate-900/30 active:scale-95 active:shadow-inner transition-all duration-300 ease-out hover:scale-105 hover:border-opacity-80 active:border-opacity-100 hover:brightness-110 border-royal-blue text-royal-blue text-center"


### PR DESCRIPTION
Update the Instagram link to the correct Macarena Gelateria profile because the previous link was not working.

---
<a href="https://cursor.com/background-agent?bcId=bc-f10c186c-e9c6-486b-a0ca-6034169f2e20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f10c186c-e9c6-486b-a0ca-6034169f2e20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

